### PR TITLE
fix: pyMEAのimportパスをv3.6.1の新しい構造に対応

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -17,5 +17,6 @@
     "Toppage",
     "usecase"
   ],
-  "flake8.args": ["--max-line-length=150", "--ignore=E203, E741,W503"]
+  "flake8.args": ["--max-line-length=150", "--ignore=E203, E741,W503"],
+  "python-envs.defaultEnvManager": "ms-python.python:pyenv"
 }

--- a/server/service/fig_service.py
+++ b/server/service/fig_service.py
@@ -9,7 +9,7 @@ matplotlib.use("Agg")  # GUIバックエンドを使用しないように設定
 from model.form_value import FormValue
 from model.peak_form_value import PeakFormValue
 from pyMEA import FigMEA, detect_peak_all, detect_peak_neg, detect_peak_pos
-from pyMEA.read.model.MEA import MEA
+from pyMEA.domain.model.MEA import MEA
 
 
 @dataclass(frozen=True)

--- a/server/test/src/unit/draw/test_FigDispatchService.py
+++ b/server/test/src/unit/draw/test_FigDispatchService.py
@@ -7,7 +7,7 @@ from enums.FigType import FigType
 from model.form_value import FormValue
 from model.peak_form_value import PeakFormValue
 from pyMEA import detect_peak_neg, read_MEA
-from pyMEA.figure.plot.plot import circuit_eles
+from pyMEA.presentation.plot.plot import circuit_eles
 from service.fig_service import FigService
 from service.FigImageDispatchService import FigImageDispatchService
 from usecase.FigUseCase import complete_data, create_figMEA

--- a/server/test/src/unit/read/test_complete_data.py
+++ b/server/test/src/unit/read/test_complete_data.py
@@ -4,7 +4,7 @@ from test.src.utils import get_resource_path
 import numpy as np
 from model.form_value import FormValue
 from pyMEA import read_MEA
-from pyMEA.figure.plot.plot import circuit_eles
+from pyMEA.presentation.plot.plot import circuit_eles
 from usecase.FigUseCase import complete_data
 
 

--- a/server/usecase/FigUseCase.py
+++ b/server/usecase/FigUseCase.py
@@ -7,8 +7,8 @@ from model.form_value import FormValue
 from model.peak_form_value import PeakFormValue
 from model.video_form_value import VideoFormValue
 from pyMEA import MEA, FigMEA
-from pyMEA.core.Electrode import Electrode
-from pyMEA.read.model.HedPath import HedPath
+from pyMEA.domain.model.Electrode import Electrode
+from pyMEA.domain.model.HedPath import HedPath
 from repository.fig_image_repository import FigImageRepository
 from service.FigDispatchServiceFactory import FigDispatchServiceFactory
 from service.mino_service import MinioService


### PR DESCRIPTION
## Summary

- `pyMEA.read.model.MEA` → `pyMEA.domain.model.MEA`
- `pyMEA.core.Electrode` → `pyMEA.domain.model.Electrode`
- `pyMEA.read.model.HedPath` → `pyMEA.domain.model.HedPath`
- `pyMEA.figure.plot.plot` → `pyMEA.presentation.plot.plot`

pyMEAがDDDスタイル（`domain/`・`presentation/`）に再構成されたことに伴い、Flaskサーバーおよびテストコード内の旧importパスを新しい構造に合わせて修正。

## 対象ファイル

- `server/service/fig_service.py`
- `server/usecase/FigUseCase.py`
- `server/test/src/unit/draw/test_FigDispatchService.py`
- `server/test/src/unit/read/test_complete_data.py`
- `.vscode/settings.json` (Python環境マネージャー設定を追加)

## Test plan

- [ ] `pyMEA.domain.model.MEA` / `Electrode` / `HedPath` がimportできることを確認
- [ ] `pyMEA.presentation.plot.plot.circuit_eles` がimportできることを確認
- [ ] テストリソースファイル (`230615_day2_test_5s_.hed`) を配置した上でユニットテストが通ることを確認
- [ ] Flaskサーバーが正常に起動することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)