### PR TITLE
feat: npzファイルを画面から読み込む機能を追加

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -17,5 +17,6 @@
     "Toppage",
     "usecase"
   ],
-  "flake8.args": ["--max-line-length=150", "--ignore=E203, E741,W503"]
+  "flake8.args": ["--max-line-length=150", "--ignore=E203, E741,W503"],
+  "python-envs.defaultEnvManager": "ms-python.python:pyenv"
 }

--- a/client/src/components/SharedMEA.tsx
+++ b/client/src/components/SharedMEA.tsx
@@ -1,5 +1,9 @@
 import React, { createContext, ReactNode, useContext, useState } from "react";
-import { FileName, useFileHandler } from "../hooks/useFileHandler";
+import {
+  FileName,
+  InputMode,
+  useFileHandler,
+} from "../hooks/useFileHandler";
 import { HedValue } from "../types/HedValue";
 import { ReadTime } from "../types/ReadTime";
 
@@ -9,12 +13,18 @@ interface SharedMeaContextType {
   hedValue: HedValue;
   readTime: ReadTime;
   meaData: Float32Array[];
+  npzFile: File | undefined;
+  npzName: string;
+  inputMode: InputMode;
   handleHedChange: (e: React.ChangeEvent<HTMLSelectElement>) => void;
   handleHedFile: (e: React.ChangeEvent<HTMLInputElement>) => Promise<void>;
   handleReadTime: (e: React.ChangeEvent<HTMLInputElement>) => void;
   handleBioInput: (e: React.ChangeEvent<HTMLInputElement>) => Promise<void>;
   handleRefreshHedFile: () => void;
   handleReadBio: () => Promise<void>;
+  handleNpzInput: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  handleRefreshNpzFile: () => void;
+  handleInputMode: (mode: InputMode) => void;
   isPython: boolean;
   togglePython: () => void;
 }
@@ -36,12 +46,18 @@ export const SharedMeaProvider: React.FC<SharedMeaProviderProps> = ({
     hedValue,
     readTime,
     meaData,
+    npzFile,
+    npzName,
+    inputMode,
     handleHedChange,
     handleHedFile,
     handleReadTime,
     handleBioInput,
     handleRefreshHedFile,
     handleReadBio,
+    handleNpzInput,
+    handleRefreshNpzFile,
+    handleInputMode,
   } = useFileHandler();
   const [isPython, setIsPython] = useState(true);
   const togglePython = () => {
@@ -56,12 +72,18 @@ export const SharedMeaProvider: React.FC<SharedMeaProviderProps> = ({
         hedValue,
         readTime,
         meaData,
+        npzFile,
+        npzName,
+        inputMode,
         handleHedChange,
         handleHedFile,
         handleReadTime,
         handleBioInput,
         handleRefreshHedFile,
         handleReadBio,
+        handleNpzInput,
+        handleRefreshNpzFile,
+        handleInputMode,
         isPython,
         togglePython,
       }}

--- a/client/src/components/organism/body/Body.tsx
+++ b/client/src/components/organism/body/Body.tsx
@@ -1,6 +1,8 @@
 import { ResFigure } from "../figure/ResFigure";
 import { Form } from "./form/Form";
 import { ReadBio } from "./readMeaFile/ReadBio";
+import { NpzInput } from "./readMeaFile/NpzInput";
+import { InputModeTabs } from "./readMeaFile/InputModeTabs";
 import { useDataSubmission } from "../../../hooks/useDataSubmition";
 import { ChPad } from "../ChPad/ChPad";
 import { useChPad } from "../../../hooks/useChPad";
@@ -21,12 +23,18 @@ export const Body: React.FC<BodyProps> = ({ pageName }) => {
     hedValue,
     readTime,
     meaData,
+    npzFile,
+    npzName,
+    inputMode,
     handleHedChange,
     handleHedFile,
     handleReadTime,
     handleBioInput,
     handleRefreshHedFile,
     handleReadBio,
+    handleNpzInput,
+    handleRefreshNpzFile,
+    handleInputMode,
     isPython,
     togglePython,
   } = useSharedMEA();
@@ -51,13 +59,15 @@ export const Body: React.FC<BodyProps> = ({ pageName }) => {
     handleRemoveImg,
   } = useDataSubmission(
     pageName,
-    fileName.bioName,
+    inputMode === "npz" ? npzName : fileName.bioName,
     readTime,
     activeChs,
     meaData,
     hedValue,
     peakFormValue,
-    isPython
+    isPython,
+    inputMode,
+    npzFile
   );
 
   const pythonAndGoPages: string[] = [
@@ -68,22 +78,25 @@ export const Body: React.FC<BodyProps> = ({ pageName }) => {
     PageName.PLOT_PEAKS,
   ];
 
+  // 現在のモードで読み込み中のファイル名 (図の取得・削除キーに使う)
+  const currentFileName = inputMode === "npz" ? npzName : fileName.bioName;
+
   useEffect(() => {
-    if (fileName.bioName) {
+    if (currentFileName) {
       const func = async () => {
-        const db_images = await get_images(pageName, fileName.bioName);
+        const db_images = await get_images(pageName, currentFileName);
         setImageResponses(db_images);
       };
       func();
     }
 
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [fileName.bioName]);
+  }, [currentFileName]);
 
   const handleDeleteAllFigure = () => {
     const isDelete = confirm("すべての図を削除しますか？");
     if (isDelete) {
-      delete_all_image(pageName, fileName.bioName);
+      delete_all_image(pageName, currentFileName);
       setImageResponses([]);
       toast.error("Figureを全件削除しました", {
         position: "top-right",
@@ -97,18 +110,31 @@ export const Body: React.FC<BodyProps> = ({ pageName }) => {
     <div className="flex h-screen-minus-topbar flex-1">
       {/* Input Panel */}
       <div className="flex flex-col w-input min-w-input max-w-input bg-[var(--bg-panel)] border-r border-[var(--border-subtle)] overflow-y-auto hide-scrollbar">
-        <ReadBio
-          isBioRead={isBioRead}
-          hedValue={hedValue}
-          readTime={readTime}
-          fileName={fileName}
-          handleHedChange={handleHedChange}
-          handleHedFile={handleHedFile}
-          handleBioInput={handleBioInput}
-          handleReadTime={handleReadTime}
-          handleRefreshHedFile={handleRefreshHedFile}
-          handleReadBio={handleReadBio}
+        <InputModeTabs
+          inputMode={inputMode}
+          handleInputMode={handleInputMode}
         />
+
+        {inputMode === "npz" ? (
+          <NpzInput
+            npzName={npzName}
+            handleNpzInput={handleNpzInput}
+            handleRefreshNpzFile={handleRefreshNpzFile}
+          />
+        ) : (
+          <ReadBio
+            isBioRead={isBioRead}
+            hedValue={hedValue}
+            readTime={readTime}
+            fileName={fileName}
+            handleHedChange={handleHedChange}
+            handleHedFile={handleHedFile}
+            handleBioInput={handleBioInput}
+            handleReadTime={handleReadTime}
+            handleRefreshHedFile={handleRefreshHedFile}
+            handleReadBio={handleReadBio}
+          />
+        )}
 
         {chPadPages.includes(pageName) ? (
           <ChPad

--- a/client/src/components/organism/body/readMeaFile/InputModeTabs.tsx
+++ b/client/src/components/organism/body/readMeaFile/InputModeTabs.tsx
@@ -1,0 +1,38 @@
+import { InputMode } from "../../../../hooks/useFileHandler";
+
+type InputModeTabsProps = {
+  inputMode: InputMode;
+  handleInputMode: (mode: InputMode) => void;
+};
+
+const tabs: { mode: InputMode; label: string }[] = [
+  { mode: "bio", label: ".hed / .bio" },
+  { mode: "npz", label: ".npz" },
+];
+
+export const InputModeTabs: React.FC<InputModeTabsProps> = ({
+  inputMode,
+  handleInputMode,
+}) => {
+  return (
+    <div className="flex gap-1 p-2 border-b border-[var(--border-subtle)]">
+      {tabs.map(({ mode, label }) => {
+        const isActive = inputMode === mode;
+        return (
+          <button
+            key={mode}
+            type="button"
+            onClick={() => handleInputMode(mode)}
+            className={`flex-1 px-3 py-1.5 text-xs font-ui font-medium rounded-md transition-all duration-150 ${
+              isActive
+                ? "bg-[var(--accent-glow)] text-green-400 ring-1 ring-green-500/30"
+                : "text-slate-400 hover:bg-[var(--bg-hover)] hover:text-slate-200"
+            }`}
+          >
+            {label}
+          </button>
+        );
+      })}
+    </div>
+  );
+};

--- a/client/src/components/organism/body/readMeaFile/NpzInput.tsx
+++ b/client/src/components/organism/body/readMeaFile/NpzInput.tsx
@@ -1,0 +1,66 @@
+import { ChangeEvent, useRef } from "react";
+
+type NpzInputProps = {
+  npzName: string;
+  handleNpzInput: (e: ChangeEvent<HTMLInputElement>) => void;
+  handleRefreshNpzFile: () => void;
+};
+
+export const NpzInput: React.FC<NpzInputProps> = ({
+  npzName,
+  handleNpzInput,
+  handleRefreshNpzFile,
+}) => {
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const handleFileButtonClick = () => {
+    if (fileInputRef.current) {
+      fileInputRef.current.click();
+    }
+  };
+
+  return (
+    <div className="p-4 panel-section">
+      <div className="flex items-center gap-2 mb-3">
+        <div className="w-1 h-4 rounded-full bg-green-500/60" />
+        <span className="text-xs font-semibold uppercase tracking-wider text-slate-400 font-ui">
+          .npz Data Input
+        </span>
+      </div>
+
+      <button
+        type="button"
+        className="w-full px-4 py-2 text-sm font-ui font-medium text-green-400 bg-[var(--accent-dim)] border border-green-500/20 rounded-md hover:bg-[var(--accent-muted)] hover:border-green-500/30 transition-all duration-150 focus:outline-none focus:ring-2 focus:ring-green-500/30"
+        onClick={handleFileButtonClick}
+      >
+        .npzファイルを選択
+      </button>
+      <input
+        ref={fileInputRef}
+        onChange={handleNpzInput}
+        type="file"
+        accept=".npz"
+        className="hidden"
+      />
+
+      <p className="mt-3 text-xs text-slate-500 font-ui leading-relaxed">
+        サンプリングレート・GAIN・電極間距離・読み込み範囲は npz
+        ファイルから自動で復元されます。
+      </p>
+
+      {npzName ? (
+        <div className="flex items-center justify-between mt-3 px-1">
+          <span className="font-mono text-xs text-green-400/80 truncate">
+            {npzName}
+          </span>
+          <button
+            className="text-xs font-ui font-medium text-slate-400 hover:text-slate-200 bg-[var(--bg-hover)] px-2.5 py-1 rounded transition-colors duration-150"
+            onClick={handleRefreshNpzFile}
+          >
+            Reset
+          </button>
+        </div>
+      ) : null}
+    </div>
+  );
+};

--- a/client/src/hooks/fetchApi.ts
+++ b/client/src/hooks/fetchApi.ts
@@ -54,6 +54,32 @@ export const fetchCreateFigure = async (
   }
 };
 
+// npzファイルをそのまま送信する (描画メタデータはバックエンドがnpzから復元する)
+export const fetchCreateFigureNpz = async (
+  rootUrl: string,
+  value: RequestEntity,
+  npzFile: File,
+  activeChs: number[] | null
+) => {
+  const url = rootUrl + "/draw/npz";
+
+  const formData = new FormData();
+  formData.append("npz", npzFile);
+  value.chs = activeChs ? activeChs : [];
+  formData.append("jsonData", JSON.stringify(value));
+
+  try {
+    const res = await fetch(url, {
+      method: "POST",
+      body: formData,
+    });
+    const resData = await res.json();
+    return resData;
+  } catch (e) {
+    console.error(e);
+  }
+};
+
 export const get_images = async (pageName: string, fileName: string) => {
   const url = `${GIN_ROOT_URL}/fig/${pageName}/${fileName}`;
   const res = await fetch(url);

--- a/client/src/hooks/useDataSubmition.ts
+++ b/client/src/hooks/useDataSubmition.ts
@@ -6,6 +6,7 @@ import { HedValue } from "../types/HedValue";
 import {
   delete_image,
   fetchCreateFigure,
+  fetchCreateFigureNpz,
   FLASK_ROOT_URL,
   GIN_ROOT_URL,
 } from "./fetchApi";
@@ -14,6 +15,7 @@ import { toast } from "react-toastify";
 import { ImgResponse } from "../types/ImgResponse";
 import { chPadPages, onlyPythonList, PageName } from "../enum/PageName";
 import { ReadTime } from "../types/ReadTime";
+import { InputMode } from "./useFileHandler";
 
 export const useDataSubmission = (
   pageName: string,
@@ -23,7 +25,9 @@ export const useDataSubmission = (
   meaData: Float32Array[],
   hedValue: HedValue,
   peakFormValue: PeakFormValue,
-  isPython: boolean
+  isPython: boolean,
+  inputMode: InputMode,
+  npzFile: File | undefined
 ) => {
   const [values, setValues] = useState<ChFormValue>(() => {
     const stored = localStorage.getItem("chFormValue");
@@ -86,7 +90,7 @@ export const useDataSubmission = (
       return;
     }
     setDisabled(true);
-    if (!meaData[0]) {
+    if (inputMode === "npz" ? !npzFile : !meaData[0]) {
       alert("MEAデータが読み込まれていません");
       setDisabled(false);
       return;
@@ -153,17 +157,32 @@ export const useDataSubmission = (
       hideProgressBar: true,
     });
 
+    // npzはバックエンド(pyMEA)で読み込むためFlask固定。それ以外は従来通り。
     const rootUrl =
-      isPython || onlyPythonList.includes(pageName as PageName)
+      inputMode === "npz" ||
+      isPython ||
+      onlyPythonList.includes(pageName as PageName)
         ? FLASK_ROOT_URL
         : GIN_ROOT_URL;
 
-    const resData = await fetchCreateFigure(
-      rootUrl,
-      peakRequestEntity,
-      meaData,
-      chPadPages.includes(pageName as PageName) ? activeChs : null
-    );
+    const activeChsArg = chPadPages.includes(pageName as PageName)
+      ? activeChs
+      : null;
+
+    const resData =
+      inputMode === "npz" && npzFile
+        ? await fetchCreateFigureNpz(
+            rootUrl,
+            peakRequestEntity,
+            npzFile,
+            activeChsArg
+          )
+        : await fetchCreateFigure(
+            rootUrl,
+            peakRequestEntity,
+            meaData,
+            activeChsArg
+          );
 
     // resData.job_id があるなら SSE を Promise 化して返す
     if (resData?.job_id) {

--- a/client/src/hooks/useFileHandler.ts
+++ b/client/src/hooks/useFileHandler.ts
@@ -6,6 +6,8 @@ import { readBio } from "./readBio";
 import { ReadTime } from "../types/ReadTime";
 import { toast } from "react-toastify";
 
+export type InputMode = "bio" | "npz";
+
 export type MeaFile = {
   hedFile: File | undefined;
   bioFile: File | undefined;
@@ -28,6 +30,9 @@ export const useFileHandler = () => {
   const [meaData, setMeaData] = useState<Float32Array[]>([]);
   const [readTime, setReadTime] = useState<ReadTime>({ start: 0, end: 30 });
   const [isBioRead, setIsBioRead] = useState(false);
+  const [npzFile, setNpzFile] = useState<File | undefined>(undefined);
+  const [npzName, setNpzName] = useState("");
+  const [inputMode, setInputMode] = useState<InputMode>("bio");
 
   const handleHedChange = (e: ChangeEvent<HTMLSelectElement>) => {
     const { name, value } = e.target;
@@ -100,17 +105,56 @@ export const useFileHandler = () => {
     });
   };
 
+  // .npzファイルが選択されたら保持する (パースはバックエンドに委譲)
+  const handleNpzInput = (e: ChangeEvent<HTMLInputElement>) => {
+    const file = handleFileFromChangeEvent(e);
+    if (file) {
+      setNpzFile(file);
+      setNpzName(file.name);
+      toast.success("npzファイルを選択しました", {
+        position: "top-right",
+        autoClose: 3000,
+        hideProgressBar: true,
+      });
+    }
+  };
+
+  // .npzファイルのリセット
+  const handleRefreshNpzFile = () => {
+    setNpzFile(undefined);
+    setNpzName("");
+  };
+
+  // 入力モードを切り替える (切替時に他方のファイル状態をクリアして排他にする)
+  const handleInputMode = (mode: InputMode) => {
+    if (mode === inputMode) return;
+    setInputMode(mode);
+    if (mode === "npz") {
+      setMeaFile({ hedFile: undefined, bioFile: undefined });
+      setFileName({ hedName: "", bioName: "" });
+      setMeaData([]);
+    } else {
+      handleRefreshNpzFile();
+    }
+  };
+
   return {
     fileName,
     isBioRead,
     hedValue,
     readTime,
     meaData,
+    npzFile,
+    npzName,
+    inputMode,
     handleHedChange,
     handleHedFile,
     handleReadTime,
     handleBioInput,
     handleRefreshHedFile,
     handleReadBio,
+    handleNpzInput,
+    handleRefreshNpzFile,
+    handleInputMode,
   } as const;
 };

--- a/server/controller/figure_controller.py
+++ b/server/controller/figure_controller.py
@@ -4,8 +4,8 @@ import time
 import uuid
 
 from flask import Blueprint, Response, jsonify, stream_with_context
-from model.FigRequest import decode_request
-from usecase.FigUseCase import FigUseCase
+from model.FigRequest import decode_request, decode_request_npz
+from usecase.FigUseCase import FigUseCase, NpzFigUseCase
 
 figure = Blueprint("figure", __name__)
 
@@ -27,6 +27,26 @@ def background_draw(fig_request, job_id):
     with app.app_context():
         try:
             result = FigUseCase(fig_request).create_fig()
+            jobs[job_id] = {"status": "done", "result": result}
+        except Exception as e:
+            jobs[job_id] = {"status": "failed", "result": str(e)}
+
+
+@figure.route("/draw/npz", methods=["POST"])
+def draw_npz():
+    npz_request = decode_request_npz()
+    job_id = str(uuid.uuid4())
+    jobs[job_id] = {"status": "pending", "result": None}
+    threading.Thread(target=background_draw_npz, args=(npz_request, job_id)).start()
+    return jsonify({"job_id": job_id}), 202
+
+
+def background_draw_npz(npz_request, job_id):
+    from app import app
+
+    with app.app_context():
+        try:
+            result = NpzFigUseCase(npz_request).create_fig()
             jobs[job_id] = {"status": "done", "result": result}
         except Exception as e:
             jobs[job_id] = {"status": "failed", "result": str(e)}

--- a/server/model/FigRequest.py
+++ b/server/model/FigRequest.py
@@ -1,6 +1,7 @@
 import json
+import os
+import tempfile
 from dataclasses import dataclass
-from trace import Trace
 
 import numpy as np
 from flask import request
@@ -10,6 +11,29 @@ from flask import request
 class FigRequest:
     data: np.ndarray[float]
     json_data: dict
+
+
+@dataclass(frozen=True)
+class NpzFigRequest:
+    npz_path: str
+    json_data: dict
+
+
+def decode_request_npz():
+    npz_file = request.files.get("npz")
+    json_data = request.form.get("jsonData")
+    if json_data:
+        json_data = json.loads(json_data)
+
+    tmp = tempfile.NamedTemporaryFile(suffix=".npz", delete=False)
+    try:
+        tmp.write(npz_file.read())
+        tmp.flush()
+        tmp_path = tmp.name
+    finally:
+        tmp.close()
+
+    return NpzFigRequest(tmp_path, json_data)
 
 
 def decode_request():

--- a/server/service/fig_service.py
+++ b/server/service/fig_service.py
@@ -9,7 +9,7 @@ matplotlib.use("Agg")  # GUIバックエンドを使用しないように設定
 from model.form_value import FormValue
 from model.peak_form_value import PeakFormValue
 from pyMEA import FigMEA, detect_peak_all, detect_peak_neg, detect_peak_pos
-from pyMEA.read.model.MEA import MEA
+from pyMEA.domain.model.MEA import MEA
 
 
 @dataclass(frozen=True)

--- a/server/test/src/unit/draw/test_FigDispatchService.py
+++ b/server/test/src/unit/draw/test_FigDispatchService.py
@@ -7,7 +7,7 @@ from enums.FigType import FigType
 from model.form_value import FormValue
 from model.peak_form_value import PeakFormValue
 from pyMEA import detect_peak_neg, read_MEA
-from pyMEA.figure.plot.plot import circuit_eles
+from pyMEA.presentation.plot.plot import circuit_eles
 from service.fig_service import FigService
 from service.FigImageDispatchService import FigImageDispatchService
 from usecase.FigUseCase import complete_data, create_figMEA

--- a/server/test/src/unit/read/test_complete_data.py
+++ b/server/test/src/unit/read/test_complete_data.py
@@ -4,7 +4,7 @@ from test.src.utils import get_resource_path
 import numpy as np
 from model.form_value import FormValue
 from pyMEA import read_MEA
-from pyMEA.figure.plot.plot import circuit_eles
+from pyMEA.presentation.plot.plot import circuit_eles
 from usecase.FigUseCase import complete_data
 
 

--- a/server/test/src/unit/read/test_npz_usecase.py
+++ b/server/test/src/unit/read/test_npz_usecase.py
@@ -1,0 +1,84 @@
+import os
+import tempfile
+import unittest
+from unittest.mock import patch
+
+import numpy as np
+from enums.FigType import FigType
+from model.FigRequest import NpzFigRequest
+from pyMEA.domain.model.HedPath import HedPath
+from pyMEA.domain.model.MEA import MEA
+from pyMEA.infrastructure.npz_io import save_mea_npz
+from usecase.FigUseCase import NpzFigUseCase
+
+
+def _make_synth_npz(path: str, sampling_rate=1000, gain=2000, electrode_distance=450):
+    """テスト用の合成MEAデータ(時刻 + 64ch, 1秒)をnpzで保存する。"""
+    n = sampling_rate
+    t = np.arange(n) / sampling_rate
+    arr = np.vstack([t] + [np.sin(2 * np.pi * 5 * t + ch) for ch in range(64)]).astype(
+        np.float64
+    )
+    mea = MEA(HedPath("tmp.hed"), 0, 1, sampling_rate, gain, arr)
+    save_mea_npz(mea, path, dtype="int16", electrode_distance=electrode_distance)
+
+
+class NpzFigUseCaseTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.NamedTemporaryFile(suffix=".npz", delete=False)
+        self.tmp.close()
+        _make_synth_npz(self.tmp.name)
+        self.json_data = {
+            "figType": "showAll",
+            "filename": "test_synth.npz",
+            "volt_min": -200,
+            "volt_max": 200,
+            "x_ratio": 8,
+            "y_ratio": 8,
+            "dpi": 100,
+            "chs": [],
+        }
+
+    def tearDown(self):
+        if os.path.exists(self.tmp.name):
+            os.remove(self.tmp.name)
+
+    @patch("usecase.FigUseCase.FigImageRepository")
+    @patch("usecase.FigUseCase.MinioService")
+    def test_npzから画像が生成される(self, mock_minio, mock_repo):
+        mock_minio.saves.side_effect = lambda images: images
+        mock_repo.insert.side_effect = lambda img: img.fig_type
+
+        req = NpzFigRequest(self.tmp.name, self.json_data)
+        result = NpzFigUseCase(req).create_fig()
+
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0], FigType.SHOW_ALL)
+
+    @patch("usecase.FigUseCase.FigImageRepository")
+    @patch("usecase.FigUseCase.MinioService")
+    def test_処理後にtempファイルが削除される(self, mock_minio, mock_repo):
+        mock_minio.saves.side_effect = lambda images: images
+        mock_repo.insert.side_effect = lambda img: img.fig_type
+
+        req = NpzFigRequest(self.tmp.name, self.json_data)
+        NpzFigUseCase(req).create_fig()
+
+        self.assertFalse(os.path.exists(self.tmp.name))
+
+    @patch("usecase.FigUseCase.FigImageRepository")
+    @patch("usecase.FigUseCase.MinioService")
+    def test_読み込み失敗時もtempファイルが削除される(self, mock_minio, mock_repo):
+        # 不正なnpzパスを渡すと read_MEA_npz が例外を投げる
+        with open(self.tmp.name, "wb") as f:
+            f.write(b"not a valid npz file")
+
+        req = NpzFigRequest(self.tmp.name, self.json_data)
+        with self.assertRaises(Exception):
+            NpzFigUseCase(req).create_fig()
+
+        self.assertFalse(os.path.exists(self.tmp.name))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/server/usecase/FigUseCase.py
+++ b/server/usecase/FigUseCase.py
@@ -1,12 +1,13 @@
+import os
 from dataclasses import dataclass
 
 import numpy as np
 from enums.FigType import FigType
-from model.FigRequest import FigRequest
+from model.FigRequest import FigRequest, NpzFigRequest
 from model.form_value import FormValue
 from model.peak_form_value import PeakFormValue
 from model.video_form_value import VideoFormValue
-from pyMEA import MEA, FigMEA
+from pyMEA import MEA, FigMEA, read_MEA_npz
 from pyMEA.domain.model.Electrode import Electrode
 from pyMEA.domain.model.HedPath import HedPath
 from repository.fig_image_repository import FigImageRepository
@@ -80,3 +81,42 @@ def create_figMEA(data, form_value: FormValue):
         data,
     )
     return FigMEA(data, Electrode(form_value.electrode_distance))
+
+
+@dataclass(frozen=True)
+class NpzFigUseCase:
+    fig_request: NpzFigRequest
+
+    def create_fig(self):
+        try:
+            pymea = read_MEA_npz(self.fig_request.npz_path)
+        finally:
+            os.remove(self.fig_request.npz_path)
+
+        json_data = {
+            **self.fig_request.json_data,
+            "start": float(pymea.data.start),
+            "end": float(pymea.data.end),
+            "hedValue": {
+                "sampling_rate": int(pymea.data.SAMPLING_RATE),
+                "gain": int(pymea.data.GAIN),
+            },
+            "electrode_distance": int(pymea.electrode.ele_dis),
+            "readTime": {
+                "start": int(pymea.data.start),
+                "end": int(pymea.data.end),
+            },
+        }
+
+        form_value = FormValue(json_data)
+        peak_form_value = PeakFormValue(json_data)
+        video_form_value = VideoFormValue(json_data)
+
+        fm = pymea.fig
+        fig_dispatch_service = FigDispatchServiceFactory.create(
+            fm, form_value, peak_form_value, video_form_value
+        )
+        image_data_list = fig_dispatch_service.create_fig()
+
+        fig_images = MinioService.saves(image_data_list)
+        return [FigImageRepository.insert(fig_image) for fig_image in fig_images]

--- a/server/usecase/FigUseCase.py
+++ b/server/usecase/FigUseCase.py
@@ -7,8 +7,8 @@ from model.form_value import FormValue
 from model.peak_form_value import PeakFormValue
 from model.video_form_value import VideoFormValue
 from pyMEA import MEA, FigMEA
-from pyMEA.core.Electrode import Electrode
-from pyMEA.read.model.HedPath import HedPath
+from pyMEA.domain.model.Electrode import Electrode
+from pyMEA.domain.model.HedPath import HedPath
 from repository.fig_image_repository import FigImageRepository
 from service.FigDispatchServiceFactory import FigDispatchServiceFactory
 from service.mino_service import MinioService


### PR DESCRIPTION
## Summary

pyMEA の npz 保存機能（`PyMEA.save_npz` / `read_MEA_npz`）に対応し、`.npz` ファイルを画面からアップロードして描画できるようにしました。

`.npz` には sampling_rate / gain / start / end / electrode_distance / 電位データがすべて含まれるため、フロントでのバイナリ解析は不要です。バックエンドの `read_MEA_npz()` で直接 `FigMEA` を生成し、既存の描画パイプライン（`FigDispatchServiceFactory` 以降の SSE + MinIO 永続化）をそのまま再利用しています。

## バックエンド

- **`NpzFigRequest` / `decode_request_npz`** (`model/FigRequest.py`): npz を `tempfile` に展開しパスを渡す
- **`NpzFigUseCase`** (`usecase/FigUseCase.py`): `read_MEA_npz` で PyMEA を生成し、npz 内蔵メタデータで `FormValue` を構築。一時ファイルは `try/finally` で確実に削除
- **`POST /draw/npz`** (`controller/figure_controller.py`): npz 用エンドポイント。ジョブ管理・SSE・永続化は既存ロジックを再利用

## フロントエンド

- **`useFileHandler`**: npz の state（`npzFile` / `npzName`）と入力モード（`bio` / `npz`）を排他管理。モード切替時に他方のファイル状態をクリア
- **`InputModeTabs` / `NpzInput`**（新規）: `.hed/.bio` ⇆ `.npz` の切替タブと npz 入力 UI
- **`fetchCreateFigureNpz`** (`fetchApi.ts`): npz を `FormData` でそのまま送信（npz はバックエンドで読むため Flask 固定）
- **`useDataSubmition`**: npz モード時の入力検証・送信先を分岐

## Test plan

- [x] `read_MEA_npz` のラウンドトリップ（save → read でメタデータ復元）
- [x] `NpzFigUseCase.create_fig` で画像が生成される（`test_npz_usecase.py`）
- [x] 処理後／読み込み失敗時ともに一時ファイルが削除される
- [x] フロント `tsc --noEmit` 型チェック通過
- [x] 変更ファイルの ESLint 通過
- [ ] 実機で `.npz` を選択 → 描画ボタン → 図表示まで確認
- [ ] 既存の `.hed`/`.bio` フローに回帰がないことを確認

## 備考

- 描画範囲は npz 内蔵の start/end（全範囲）を使用します
- 既存の resource 依存テスト（`230615_day2_test_5s_.hed` 欠損）の失敗は本 PR 以前からの既知問題で、本変更とは無関係です

🤖 Generated with [Claude Code](https://claude.com/claude-code)